### PR TITLE
Fix I key not toggling inventory visibility

### DIFF
--- a/core/src/main/kotlin/com/github/quillraven/mysticwoods/input/PlayerInputProcessor.kt
+++ b/core/src/main/kotlin/com/github/quillraven/mysticwoods/input/PlayerInputProcessor.kt
@@ -76,7 +76,7 @@ class PlayerInputProcessor(
             playerEntities.forEach { attackCmps[it].doAttack = true }
             return true
         } else if (keycode == I) {
-            uiStage.actors.get(1).isVisible = !uiStage.actors.get(1).isVisible
+            uiStage.actors.get(2).isVisible = !uiStage.actors.get(2).isVisible
         } else if (keycode == P) {
             paused = !paused
             gameStage.fire(if (paused) GamePauseEvent() else GameResumeEvent())


### PR DESCRIPTION
Currently pressing I key does not show inventory, because wrong ui layer is checked. Inventory layer is at index 2 so updated accordingly